### PR TITLE
Add HTTP basic auth token parsing

### DIFF
--- a/js/request.js
+++ b/js/request.js
@@ -199,7 +199,13 @@ function parseUrl() {
     var params = req_uri.search(true);
 
     var token = search['token'];
-    if (token === undefined) { token = getTokenFromStorage(api); }
+
+    if (token === undefined) {
+        if (/^[a-z0-9]{8}-(?:[a-z0-9]{4}-){3}[a-z0-9]{12}/.test(req_uri.username())) {
+            api = new URI(api).username('').toString();
+            token = req_uri.username();
+        } else { token = getTokenFromStorage(api); }
+    }
 
     return {
         token: token,

--- a/js/request.js
+++ b/js/request.js
@@ -201,9 +201,9 @@ function parseUrl() {
     var token = search['token'];
 
     if (token === undefined) {
-        if (/^[a-z0-9]{8}-(?:[a-z0-9]{4}-){3}[a-z0-9]{12}/.test(req_uri.username())) {
-            api = new URI(api).username('').toString();
+        if (req_uri.username()) {
             token = req_uri.username();
+            api = new URI(api).username('').toString();
         } else { token = getTokenFromStorage(api); }
     }
 


### PR DESCRIPTION
This PR adds a way to specify a token when filling a URL field. The token can now be passed through the HTTP basic auth syntax (**token[:password]@**).

If both a token is specified in the query (*?token=*...) and as a basic auth login, the query parameter will be preferred.

fix #167 