### PR TITLE
use navitia swagger for parameter autocomplete

### DIFF
--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -239,8 +239,10 @@ autocomplete.swaggerAutocomplete = function(args) {
                     }
                 }
             ).fail(function(data, status, error) {
-                utils.notifyOnError('Autocomplete', req, data, status, error);
-                console.warn('error on swagger call for req ' + req, data, error);// jshint ignore:line
+                if (data.responseText !== '') {
+                    utils.notifyOnError('Autocomplete', req, data, status, error);
+                    console.warn('error on swagger call for req ' + req, data, error);// jshint ignore:line
+                }
                 args.onError(data);
             });
         } else if ($(input).is(':focus') && $(input).autocomplete('instance')) {

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -534,8 +534,13 @@ autocomplete._customAutocompleteHelper = function(input, source, customOptions) 
     };
     if (customOptions) { $.extend(true, options, customOptions); }
     $(input).autocomplete(options).focus(function() {
-        $(this).autocomplete('search', '');
+        if ($(input).autocomplete('instance')) {
+            $(this).autocomplete('search', '');
+        }
     });
+    if ($(input).is(':focus')) {
+        $(input).focus();
+    }
 };
 
 autocomplete._makeDatetime = function(elt) {

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -210,6 +210,7 @@ autocomplete.swaggerAutocomplete = function(args) {
                 // be sure that out-of-date autocompletion will not be active
                 $(input).autocomplete('destroy');
             }
+            $(input).parent().find('.tooltips').empty();
             $.ajax({
                 headers: utils.manageToken(token),
                 dataType: 'json',
@@ -317,6 +318,7 @@ autocomplete.updateStaticAutocomplete = function(input, staticType, req, token) 
         // be shure that out-of-date autocompletion will not be active
         $(input).autocomplete('destroy');
     }
+    $(input).parent().find('.tooltips').empty();
     $.ajax({
         headers: utils.manageToken(token),
         dataType: 'json',
@@ -451,6 +453,8 @@ autocomplete.Place.prototype = Object.create(autocomplete.AbstractObject.prototy
 autocomplete.Place.prototype.api = 'places';
 autocomplete.Place.prototype.autocomplete = function(elt) {
     if (!this.types.length || this.types.indexOf('address') !== -1) {
+        var tooltips = $(elt).parent().find('.tooltips');
+
         $('<button/>')
             .html('<img src="img/pictos/MapMarker.svg" alt="map">')
             .click(function() {
@@ -471,7 +475,7 @@ autocomplete.Place.prototype.autocomplete = function(elt) {
                     width: '100%',
                 }).appendTo(div);
                 utils.notifyInfo('Click on the map to set the location.');
-            }).insertAfter(elt);
+            }).prependTo(tooltips);
 
         $('<button/>')
             .html('<img src="img/pictos/Location.svg" alt="location">')
@@ -488,7 +492,7 @@ autocomplete.Place.prototype.autocomplete = function(elt) {
                     timeout: 60000,//1min
                     maximumAge: 300000,//5min
                 });
-            }).insertAfter(elt);
+            }).prependTo(tooltips);
     }
     return autocomplete.AbstractObject.prototype.autocomplete.call(this, elt);
 };

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -119,14 +119,14 @@ autocomplete.apiAutocomplete = function() {
     });
 };
 
-autocomplete.get_param_format = function (param) {
+autocomplete.getParamFormat = function (param) {
     if (param.type === 'array') {
         return param.items.format;
     }
     return param.format;
 };
 
-autocomplete.get_param_type = function (param) {
+autocomplete.getParamType = function (param) {
     if (param.type === 'array') {
         return param.items.type;
     }
@@ -158,8 +158,8 @@ autocomplete.valueAutoComplete = function (input, key) {
                 manualFallback();
                 return null;
             }
-            var format = autocomplete.get_param_format(param);
-            var type = autocomplete.get_param_type(param);
+            var format = autocomplete.getParamFormat(param);
+            var type = autocomplete.getParamType(param);
             if (format === 'date-time' || format === 'navitia-date-time') {
                 autocomplete._makeDatetime(input);
                 return null;
@@ -175,7 +175,7 @@ autocomplete.valueAutoComplete = function (input, key) {
                 new autocomplete.PtObject().autocomplete(input);
                 return null;
             }
-            if (param.enum !== undefined) {
+            if ('enum' in param) {
                 return param.enum;
             }
 
@@ -221,11 +221,7 @@ autocomplete.swaggerAutocomplete = function(args) {
                         //nothing to do
                         return;
                     }
-                    res = res.sort(function(a, b) {
-                        if (a < b) { return -1; }
-                        if (a > b) { return 1; }
-                        return 0;
-                    });
+                    res = res.sort();
                     $(input).autocomplete({
                         close: function() { request.updateUrl($(input)[0]); },
                         source: res,

--- a/js/request.js
+++ b/js/request.js
@@ -76,7 +76,7 @@ request.urlElements = function(focusedElem) {
         }
     });
     return {'api': api, 'path': path, 'parameters': parameters, 'feature': feature};
-}
+};
 
 request.finalUrl = function(focusedElem) {
     var elements = request.urlElements(focusedElem);

--- a/js/request.js
+++ b/js/request.js
@@ -135,21 +135,19 @@ request.makeKeyValue = function(key, val, cls) {
     res.append($('<span/>').addClass('key').text(key));
 
     var valueElt = $('<input/>')
-         .attr('type', 'text')
-         .attr('placeholder', 'type your value here')
+        .attr('type', 'text')
+        .attr('placeholder', 'type your value here')
         .addClass('value')
         .addClass(cls)
         .focus(function() { this.select(); })
         .val(val)
         .appendTo(res);
-
-    autocomplete.valueAutoComplete(valueElt, key);
-
-    valueElt.on('input', function() { request.updateUrl(this); });
-    valueElt.focus(function() { request.updateUrl(this); });
+    res.append($('<span class="tooltips">'));
     res.append(request.makeDeleteButton());
 
-    // valueElt must be attached to res to call this
+    autocomplete.valueAutoComplete(valueElt, key);
+    valueElt.on('input', function() { request.updateUrl(this); });
+    valueElt.focus(function() { request.updateUrl(this); });
     if (utils.isTemplate(val)) { request.makeTemplatePath(val, valueElt); }
 
     return res;

--- a/js/request.js
+++ b/js/request.js
@@ -54,7 +54,6 @@ request.getFocusedElemValue = function(elemToTest, focusedElem, noEncoding) {
     }
 };
 
-
 request.urlElements = function(focusedElem) {
     var api = request.getFocusedElemValue($('#api input.api')[0], focusedElem, true);
     if (api.slice(-1) === '/') { api = api.slice(0, -1); }

--- a/js/request.js
+++ b/js/request.js
@@ -170,10 +170,6 @@ request.insertParam = function() {
     $('#addParam').prev().find('input').first().focus();
 };
 
-request.updateAddParamAC = function() {
-    autocomplete.addKeyAutocomplete($('#addParamInput'), 'paramKey');
-};
-
 request.submit = function() {
     var url = '?request=' + encodeURIComponent(request.finalUrl());
     var token = $('#token input.token').val();
@@ -269,7 +265,6 @@ request.manage = function() {
             $(this).parent().find('button.add').click();
         }
     });
-    $('#featureInput').focusout(request.updateAddParamAC);
 
     $('#request input').focus(function() { this.select(); });
 

--- a/js/request.js
+++ b/js/request.js
@@ -54,7 +54,8 @@ request.getFocusedElemValue = function(elemToTest, focusedElem, noEncoding) {
     }
 };
 
-request.finalUrl = function(focusedElem) {
+
+request.urlElements = function(focusedElem) {
     var api = request.getFocusedElemValue($('#api input.api')[0], focusedElem, true);
     if (api.slice(-1) === '/') { api = api.slice(0, -1); }
 
@@ -74,17 +75,21 @@ request.finalUrl = function(focusedElem) {
             parameters += '&';
         }
     });
+    return {'api': api, 'path': path, 'parameters': parameters, 'feature': feature};
+}
 
+request.finalUrl = function(focusedElem) {
+    var elements = request.urlElements(focusedElem);
     if (focusedElem === undefined) {
         // called without arg, we want pure text
-        return api + path + '/' + feature + parameters;
+        return elements.api + elements.path + '/' + elements.feature + elements.parameters;
     } else {
         // with arg, we want a rendering thing
         return sprintf('<span class="api">%s</span>' +
                        '<span class="path">%s</span>' +
                        '<span class="feature">/%s</span>' +
                        '<span class="parameters">%s</span>',
-                       api, path, feature, parameters);
+                       elements.api, elements.path, elements.feature, elements.parameters);
     }
 };
 

--- a/js/summary.js
+++ b/js/summary.js
@@ -503,11 +503,16 @@ summary.make.equipments = function(context, json) {
 };
 
 summary.make.poi = function(context, json) {
-    var type = '';
+    var res = $('<span/>');
     if (json.poi_type && json.poi_type.name) {
-        type = json.poi_type.name + ': ';
+        res.append(json.poi_type.name + ': ');
     }
-    return type + json.label;
+    res.append(json.label);
+    if (json.stands) {
+        res.append(', stands: ');
+        res.append(summary.run(context, 'stands', json.stands));
+    }
+    return res;
 };
 
 summary.make.traffic_report = function(elt, json) {

--- a/scss/request/_request.scss
+++ b/scss/request/_request.scss
@@ -35,6 +35,9 @@
         .inputDiv button:disabled {
             color: $gray;
         }
+        .tooltips {
+            white-space: nowrap;
+        }
     }
     #credentials { @include request-parts($orange); }
     #path { @include request-parts($green); }


### PR DESCRIPTION
navitia returns a partial Swagger schema when called with `OPTIONS` (and `?schema=true`)

uses this feature to get an up to date list of all the parameters for an api, and some nice autocomplete using the type of the parameter