### PR TITLE
Extend Path render

### DIFF
--- a/js/extended.js
+++ b/js/extended.js
@@ -138,7 +138,7 @@ extended.make.section = function(context, json) {
         result.append(response.render(context, json.to, 'place', 'to'));
     }
     if (json.path) {
-        result.append(response.render(context, json, 'path', 'guidance'));
+        result.append(response.render(context, json, 'path', 'path'));
     }
     (json.ridesharing_journeys || []).forEach(function(j, i) {
         result.append(response.render(context, j, 'journey', 'ridesharing_journeys', i));
@@ -314,7 +314,7 @@ extended.make.stop_area_equipment = function(context, json) {
 extended.make.path = function(context, json) {
     var res = extended.defaultExtended(context, 'paths', json);
     (json.path || []).forEach(function(obj, i) {
-        res.append(response.render(context, obj, 'instruction', 'instructions', i));
+        res.append(response.render(context, obj, 'instruction', 'paths', i));
     });
     return res;
 };

--- a/js/extended.js
+++ b/js/extended.js
@@ -137,6 +137,9 @@ extended.make.section = function(context, json) {
     if (json.to) {
         result.append(response.render(context, json.to, 'place', 'to'));
     }
+    if (json.path) {
+        result.append(response.render(context, json, 'path', 'guidance'));
+    }
     (json.ridesharing_journeys || []).forEach(function(j, i) {
         result.append(response.render(context, j, 'journey', 'ridesharing_journeys', i));
     });
@@ -304,6 +307,14 @@ extended.make.stop_area_equipment = function(context, json) {
     var res = extended.defaultExtended(context, 'equipment_details', json);
     (json.equipment_details || []).forEach(function(obj, i) {
         res.append(response.render(context, obj, 'equipment_detail', 'equipment_details', i));
+    });
+    return res;
+};
+
+extended.make.path = function(context, json) {
+    var res = extended.defaultExtended(context, 'paths', json);
+    (json.path || []).forEach(function(obj, i) {
+        res.append(response.render(context, obj, 'instruction', 'instructions', i));
     });
     return res;
 };

--- a/js/summary.js
+++ b/js/summary.js
@@ -708,6 +708,49 @@ summary.make.equipment_detail = function(context, json) {
     return res;
 };
 
+summary.make.path = function(context, json) {
+    var res = $('<span>')
+        .append(pictos.makeSnPicto(json.mode))
+        .append(' > ')
+        .append(sprintf('%d instructions', json.path.length));
+    return res;
+};
+
+summary.make.instruction = function(context, path) {
+    var res = $('<span>');
+        if (path.instruction) {
+            res.append(path.instruction);
+        } else {
+            if (path.direction === parseInt('0',10)) {
+                res.append('Continue on ');
+            } else if (path.direction < parseInt('0', 10)){
+                res.append('Turn left onto ');
+            } else {
+                res.append('Turn right onto ');
+            }
+            if (path.name === '') {
+                $('<span/>')
+                    .addClass('street')
+                    .text('Street Name Unknown')
+                .appendTo(res);
+            } else {
+                $('<span/>')
+                    .addClass('street')
+                    .text(path.name)
+                .appendTo(res);
+            }
+            res.append('. Go for ');
+            $('<span/>')
+                .addClass('length')
+                .text(sprintf('%s m.',path.length))
+            .appendTo(res);
+        }
+        res.append(' (duration: ');
+        res.append(path.duration);
+        res.append(' s)');
+    return res;
+};
+
 summary.make.note = function(context, json) {
     return json.value;
 };

--- a/js/summary.js
+++ b/js/summary.js
@@ -712,23 +712,23 @@ summary.make.path = function(context, json) {
     var res = $('<span>')
         .append(pictos.makeSnPicto(json.mode))
         .append(' > ')
-        .append(sprintf('%d instructions', json.path.length));
+        .append(sprintf('%d paths', json.path.length));
     return res;
 };
 
-summary.make.instruction = function(context, path) {
+summary.make.instruction = function(context, path_item) {
     var res = $('<span>');
-        if (path.instruction) {
-            res.append(path.instruction);
+        if (path_item.instruction) {
+            res.append(path_item.instruction);
         } else {
-            if (path.direction === parseInt('0',10)) {
+            if (path_item.direction === parseInt('0',10)) {
                 res.append('Continue on ');
-            } else if (path.direction < parseInt('0', 10)){
+            } else if (path_item.direction < parseInt('0', 10)){
                 res.append('Turn left onto ');
             } else {
                 res.append('Turn right onto ');
             }
-            if (path.name === '') {
+            if (path_item.name === '') {
                 $('<span/>')
                     .addClass('street')
                     .text('Street Name Unknown')
@@ -736,17 +736,17 @@ summary.make.instruction = function(context, path) {
             } else {
                 $('<span/>')
                     .addClass('street')
-                    .text(path.name)
+                    .text(path_item.name)
                 .appendTo(res);
             }
             res.append('. Go for ');
             $('<span/>')
                 .addClass('length')
-                .text(sprintf('%s m.',path.length))
+                .text(sprintf('%s m.',path_item.length))
             .appendTo(res);
         }
         res.append(' (duration: ');
-        res.append(path.duration);
+        res.append(path_item.duration);
         res.append(' s)');
     return res;
 };

--- a/scss/response/_object.scss
+++ b/scss/response/_object.scss
@@ -30,6 +30,21 @@
   color: $light-green;
 }
 
+.street {
+  color: $dark-gray;
+  font-weight: bold;
+}
+
+.next-street {
+  color: $dark-gray;
+  font-weight: bold;
+}
+
+.length {
+  color: $dark-gray;
+  font-weight: bold;
+}
+
 .stands-status.closed {
     color: $dark-red;
 }


### PR DESCRIPTION
## Summary
We want to highlight the Path into the playground. Currently, Path exists inside the navitia response, but it is not supported in the playground summary (**Ext** style)

![raw_path](https://user-images.githubusercontent.com/32099204/86757888-c04f8480-c043-11ea-9795-c0572a4df016.png)

It follows the work about external Street network integration (Asgard, Here, ...) and it has to take into account of current and future field Path (`instruction` is a new field)
This is the reason why we have an `if-else` here https://github.com/CanalTP/navitia-playground/compare/master...benoit-bst:extend_path_render?expand=1#diff-bc6c228feb11d35fd8ec73ab51e5fa0cR721
After these arrangements the Playground offers us, for old and new format

![playground_with_guidance](https://user-images.githubusercontent.com/32099204/86759722-00633700-c045-11ea-8295-fe91fc34d2ee.png)
