### PR TITLE
High severity - security update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1228,7 +1228,7 @@
         "etag": "^1.8.1",
         "fresh": "^0.5.2",
         "fs-extra": "3.0.1",
-        "http-proxy": "1.15.2",
+        "http-proxy": "1.18.1",
         "immutable": "^3",
         "localtunnel": "1.9.2",
         "micromatch": "^3.1.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1097,7 +1097,7 @@
       }
     },
     "bl": {
-      "version": "1.2.2",
+      "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,


### PR DESCRIPTION
Fix 2 high severity security updates found by Dependabot:
 * Upgrade bl to version 1.2.3 : https://github.com/CanalTP/navitia-playground/network/alert/package-lock.json/bl/open
 * Upgrade http-proxy to version 1.18.1: https://github.com/CanalTP/navitia-playground/network/alert/package-lock.json/http-proxy/open