### PR TITLE
Issue: complete picto list

### DIFF
--- a/js/pictos.js
+++ b/js/pictos.js
@@ -41,7 +41,6 @@ pictos.makePtPicto = function(json) {
     case 'physical_mode:BikeSharingService': img = 'BikeSharingService'; break;
     case 'physical_mode:Car': img = 'Car'; break;
     case 'physical_mode:Coach': img = 'Coach'; break;
-    case 'physical_mode:Funicular': img = 'Funicular'; break;
     case 'physical_mode:Metro': img = 'Metro'; break;
     case 'physical_mode:Taxi': img = 'Taxi'; break;
     case 'physical_mode:Tramway': img = 'Tramway'; break;
@@ -49,6 +48,10 @@ pictos.makePtPicto = function(json) {
     case 'physical_mode:CheckIn': img = 'CheckIn'; break;
     case 'physical_mode:CheckOut': img = 'CheckOut'; break;
     case 'physical_mode:Shuttle': img = 'Shuttle'; break;
+
+    case 'physical_mode:Funicular':
+    case 'physical_mode:SuspendedCableCar':
+        img = 'Funicular'; break;
 
     case 'physical_mode:Bus':
     case 'physical_mode:BusRapidTransit':
@@ -59,6 +62,7 @@ pictos.makePtPicto = function(json) {
     case 'physical_mode:LocalTrain':
     case 'physical_mode:LongDistanceTrain':
     case 'physical_mode:Train':
+    case 'physical_mode:RailShuttle':
         img = 'Train'; break;
 
     case 'physical_mode:Boat':


### PR DESCRIPTION
An issue was detected with **pictos** :
https://jira.kisio.org/browse/NAVITIAII-3334

for the occasion, we completed the list for all physical modes based on the **bible** -> https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_fr.md#physical_modestxt-requis. 
There were 2 cute missing (physical_mode:SuspendedCableCar, physical_mode:RailShuttle)

:construction: Under progress : 
The funicular picto is not realistic. We want a picto with no **suspended cable**. https://fr.wikipedia.org/wiki/Funiculaire. I know this is pernickety :speak_no_evil: 

Fix result for Railshuttle

request
![pictos](https://user-images.githubusercontent.com/32099204/110797778-c6080480-8279-11eb-914d-6e800749169a.png)

before
![before_picto](https://user-images.githubusercontent.com/32099204/110797601-8b05d100-8279-11eb-87c4-3390671009bd.png)

after
![afeter_picto](https://user-images.githubusercontent.com/32099204/110797620-8fca8500-8279-11eb-8a6d-8e84a04dfbbe.png)
