### PR TITLE
officialize terminus_schedules end point

### DIFF
--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -43,7 +43,7 @@ autocomplete._collections = [
 autocomplete._additionalFeatures = [
     'departures', 'journeys', 'places_nearby', 'pt_objects', 'route_schedules',
     'stop_schedules', 'arrivals', 'isochrones', 'heat_maps', 'traffic_reports',
-    'line_reports', 'equipment_reports'
+    'line_reports', 'equipment_reports', 'terminus_schedules'
 ];
 
 autocomplete._paramJourneyCommon = [


### PR DESCRIPTION
We can now active the `terminus_schedules` into the autocomplete. We can fight customers !

The integration work is already ready -> https://github.com/CanalTP/navitia-playground/pull/324