### PR TITLE
add freefloatings_nearby end point

### DIFF
--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -43,7 +43,7 @@ autocomplete._collections = [
 autocomplete._additionalFeatures = [
     'departures', 'journeys', 'places_nearby', 'pt_objects', 'route_schedules',
     'stop_schedules', 'arrivals', 'isochrones', 'heat_maps', 'traffic_reports',
-    'line_reports', 'equipment_reports', 'terminus_schedules'
+    'line_reports', 'equipment_reports', 'terminus_schedules', 'freefloatings_nearby'
 ];
 
 autocomplete._paramJourneyCommon = [

--- a/js/map.js
+++ b/js/map.js
@@ -160,6 +160,9 @@ map.makeFeatures = {
     poi: function(context, json) {
         return map._makeMarker(context, 'poi', json);
     },
+    free_floating: function(context, json) {
+        return map._makeMarker(context, 'free_floating', json);
+    },
     connection: function(context, json) {
         return utils.flatMap([json.origin, json.destination], function(json) {
             return map._makeMarker(context, 'stop_point', json);

--- a/js/summary.js
+++ b/js/summary.js
@@ -693,6 +693,31 @@ summary.make.terminus_schedule = function(context, json) {
     return summary.makeRoutePoint(context, json);
 };
 
+summary.make.free_floating = function(context, json) {
+    var res = $('<span/>');
+    function add(s, n) {
+        res.append(sprintf(', %s: ',s));
+        $('<span/>')
+            .addClass('gray-and-bold')
+            .text(sprintf('%s', n))
+        .appendTo(res);
+    }
+    res.append(sprintf('%s', json.type));
+    add('provider', json.provider_name)
+    res.append(', distance: ');
+    $('<span/>')
+        .addClass('gray-and-bold')
+        .text(sprintf('%s m', json.distance))
+    .appendTo(res);
+    if (json.public_id) {
+        add('public id', json.public_id)
+    }
+    if (json.battery) {
+        add('battery', json.battery)
+    }
+    return res;
+};
+
 summary.make.stop_area_equipment = function(context, json) {
     var equip_details = (json.equipment_details || []);
     var res = $('<span>')

--- a/js/summary.js
+++ b/js/summary.js
@@ -703,17 +703,17 @@ summary.make.free_floating = function(context, json) {
         .appendTo(res);
     }
     res.append(sprintf('%s', json.type));
-    add('provider', json.provider_name)
+    add('provider', json.provider_name);
     res.append(', distance: ');
     $('<span/>')
         .addClass('gray-and-bold')
         .text(sprintf('%s m', json.distance))
     .appendTo(res);
     if (json.public_id) {
-        add('public id', json.public_id)
+        add('public id', json.public_id);
     }
     if (json.battery) {
-        add('battery', json.battery)
+        add('battery', json.battery);
     }
     return res;
 };

--- a/scss/response/_object.scss
+++ b/scss/response/_object.scss
@@ -45,6 +45,11 @@
   font-weight: bold;
 }
 
+.gray-and-bold {
+  color: $dark-gray;
+  font-weight: bold;
+}
+
 .stands-status.closed {
     color: $dark-red;
 }


### PR DESCRIPTION
A new end point was added into Navitia, `freefloatings_nearby`.
We want a good summary to expose **freefloating informations**. This PR aims to that

For a request like that:
![freefloating_request](https://user-images.githubusercontent.com/32099204/114084376-67519d00-98b0-11eb-8c59-2520d65d7a4e.png)

We have:
![freefloating_response](https://user-images.githubusercontent.com/32099204/114084429-733d5f00-98b0-11eb-9fea-2ee45b9db1de.png)

:warning: For the moment, we expose `STATION`, `CAR`, `MOTORSCOOTER`, etc... But when pictos will be ready, we'll change raw text by fluffy pictos
:information_source:  Map are available like with `/places_nearby`
